### PR TITLE
Fix React imports

### DIFF
--- a/plugins/rollup.js
+++ b/plugins/rollup.js
@@ -196,6 +196,8 @@ const mappedModules = {
       return {
         code: `\
           const {React} = globalThis.Metaversefile.exports;
+          const {forwardRef, createContext, createElement, Fragment, Children, isValidElement, cloneElement, memo, Component, useEffect, useState, useRef, useLayoutEffect, useMemo, useCallback, useContext, useReducer, useImperativeHandle, useDebugValue} = React;
+          export {forwardRef, createContext, createElement, Fragment, Children, isValidElement, cloneElement, memo, Component, React, useEffect, useState, useRef, useLayoutEffect, useMemo, useCallback, useContext, useReducer, useImperativeHandle, useDebugValue};
           export default React;
         `,
       };


### PR DESCRIPTION
Currently, React itself will work, but none of module imports do -- i.e. hooks, or anything in React you would want to use. Breaks all apps.

This fixes this by exposing all of the imports as individual imports into the rollup compiler script.