### PR TITLE
bugfix physics components

### DIFF
--- a/public/type_templates/glb.js
+++ b/public/type_templates/glb.js
@@ -33,6 +33,14 @@ export default e => {
     app.setComponent(key, value);
   }
   
+  // * true by default
+  let appHasPhysics = true;
+  const hasPhysicsComponent = app.hasComponent('physics');
+  if (hasPhysicsComponent) {
+    const physicsComponent = app.getComponent('physics');
+    appHasPhysics = physicsComponent;
+  }
+  
   app.glb = null;
   const animationMixers = [];
   const uvScrolls = [];
@@ -199,37 +207,15 @@ export default e => {
       app.add(o);
       o.updateMatrixWorld();
       
-      const _addPhysics = async physicsComponent => {
-        let physicsId;
-        switch (physicsComponent.type) {
-          case 'triangleMesh': {
-            physicsId = physics.addGeometry(o);
-            break;
-          }
-          case 'convexMesh': {
-            physicsId = physics.addConvexGeometry(o);
-            break;
-          }
-          default: {
-            physicsId = null;
-            break;
-          }
-        }
-        if (physicsId !== null) {
+      if (appHasPhysics) {
+        const _addPhysics = async () => {
+          const physicsId = physics.addGeometry(o);
           physicsIds.push(physicsId);
-        } else {
-          console.warn('glb unknown physics component', physicsComponent);
-        }
-      };
-      let physicsComponent = app.getComponent('physics');
-      if (physicsComponent) {
-        if (physicsComponent === true) {
-          physicsComponent = {
-            type: 'triangleMesh',
-          };
-        }
-        _addPhysics(physicsComponent);
+        };
+
+        _addPhysics();
       }
+
       o.traverse(o => {
         if (o.isMesh) {
           o.frustumCulled = false;


### PR DESCRIPTION
This ports Arya's bugfixes from totum
https://github.com/webaverse/totum/pull/158/files

How to test:
1. Go to a .scn file and add this to a glb app :
```
"components": [
  {
    "key": "physics",
     "value": true
  }
]
```
2. Test both `true` and `false` for the value of the physics component 
3. When you set the value to `true`, the glb should have physics in the world
4. When you set the value to `false` the glb should have no physics in the world
5. Without the component ( simply remove the component from .scn file ) the glb should have physics in the world
This means that by default the glb model will have physics in the world

These things need to be added to our documents 
