### PR TITLE
Add some padding radius to VRM capsule

### DIFF
--- a/public/type_templates/vrm.js
+++ b/public/type_templates/vrm.js
@@ -50,8 +50,9 @@ export default e => {
 
      const _addPhysics = () => {
       const {height, width} = app.avatarRenderer.getAvatarSize();
+      const widthPadding = 0.5; // Padding around the avatar since the base width is computed from shoulder distance
 
-      const capsuleRadius = width / 2;
+      const capsuleRadius = (width / 2) + widthPadding;
       const capsuleHalfHeight = height / 2;
 
       const halfAvatarCapsuleHeight = (height + width) / 2; // (full world height of the capsule) / 2


### PR DESCRIPTION
Adds a bit of radius around VRM chracters.
Part of the fix for static VRMs for https://github.com/upstreet-labs/app/issues/220