### PR TITLE
Remove dom from sceneLowerPriority when destroy

### DIFF
--- a/public/type_templates/react.js
+++ b/public/type_templates/react.js
@@ -50,6 +50,7 @@ export default e => {
 
   useCleanup(() => {
     if (dom) {
+      sceneLowerPriority.remove(dom);
       dom.destroy();
     }
   });


### PR DESCRIPTION
This is the fixes of this error
https://github.com/upstreet-labs/app/issues/127
We need to remove dom element from sceneLowerPriority when destroying it